### PR TITLE
Py3, Py2, & Gnip V2 compatibility

### DIFF
--- a/src/CountTwitterRules.py
+++ b/src/CountTwitterRules.py
@@ -14,6 +14,7 @@ class CountTwitterRules(SaveThread):
     def write(self, file_name):
         self.logger.debug("CountTwitterRules is writing.")
         count_map = {}
+        rule_tags = {}
         count = 0
         for act in self.string_buffer.split("\n"):
             #self.logger.debug(str(act))
@@ -24,7 +25,8 @@ class CountTwitterRules(SaveThread):
             if "gnip" in act_json:
                 if "matching_rules" in act_json["gnip"]:
                     for mr in act_json["gnip"]["matching_rules"]:
-                        rule = mr["value"]
+                        rule = mr["id"]
+                        rule_tags[mr["id"]] = mr["tag"]
                         #self.logger.debug(str(rule))
                         if rule in count_map:
                             count_map[rule] += 1
@@ -41,20 +43,19 @@ class CountTwitterRules(SaveThread):
             fp = open(file_name, "a")
             #sys.stdout.write("(%s) sample %d tweets (%d seconds)\n"%
             #        (datetime.datetime.now(), count, self.timeSpan))
-            first_col = max([len(x) for x in count_map.keys()]) + 3
+            #first_col = max([len(str(x)) for x in count_map.keys()]) + 3
             count_mapKeys = sorted(count_map.keys(), key=count_map.__getitem__)
             count_mapKeys.reverse()
             for r in count_mapKeys:
                 # for dump to file
-                r_no_comma = r.replace(",","COMMA")
-                write_str = "{}, {}, {}, {}, {}\n".format(now, r_no_comma, count_map[r], count, self.timeSpan)
+                write_str = "{}, {}, {}, {}, {}\n".format(now, r, rule_tags[r], count_map[r], count, self.timeSpan)
                 fp.write(write_str)
                 # for dump to stdout
                 #sys.stdout.write("%s: %s (%4d tweets matched)   %3.4f tweets/second\n"%
                 #(r, '.'*(first_col-len(r)), count_map[r], float(count_map[r])/self.timeSpan)) 
             fp.close()
             self.logger.info("saved file %s"%file_name)
-        except Exception, e:
+        except Exception as e:
             self.logger.error("write failed: %s"%e)
             raise e
 

--- a/src/CustomOutput.py
+++ b/src/CustomOutput.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+__author__ = 'Fiona Pigott'
+
+from SaveThread import SaveThread
+import gzip
+import json
+import datetime 
+
+
+# Twitter Snowflake ID to timestamp (and back)
+# https://github.com/client9/snowflake2time/
+# Nick Galbreath @ngalbreath nickg@client9.com
+# Public Domain -- No Copyright -- Cut-n-Paste!
+def snowflake2utc(sf):
+    sf_int = int(sf)
+    return int(((sf_int >> 22) + 1288834974657) / 1000.0)
+def make_utc_timestamp(timestamp):
+    date_obj = datetime.datetime.strptime(timestamp.split(".")[0], "%Y-%m-%dT%H:%M:%S")
+    return str(int((date_obj - datetime.datetime(1970,1,1)).total_seconds()))
+
+class SaveThreadGnacs(SaveThread):
+    def __init__(self, _buffer, _feedname, _savepath, _rootLogger, _startTs, _spanTs, **kwargs):
+        SaveThread.__init__(self, _buffer, _feedname, _savepath, _rootLogger, _startTs, _spanTs, **kwargs)
+
+    def write(self, file_name):
+        try:
+            # create CSV output and write it to an output to file
+            fp = gzip.open(file_name, "a")
+            buffer_formated = ''
+            for act in self.string_buffer.split("\n"):
+                if act.strip() is None or act.strip() == '':
+                    continue
+                act_json = json.loads(act)
+                try:
+                    # tweetid, time of tweet, time of like, user tweeting, user liking,
+                    time_of_tweet = str(snowflake2utc(act_json["object"]["id"].split(":")[-1]))
+                    time_of_like = make_utc_timestamp(act_json["postedTime"]) 
+                    act_formated = (
+                        act_json["object"]["id"].split(":")[-1] + "," +
+                        time_of_tweet + "," + time_of_like + "," +
+                        act_json["actor"]["id"].split(":")[-1] + "," +
+                        act_json["object"]["actor"]["id"].split(":")[-1]
+                        )
+                except Exception as e:
+                    self.logger.error("Custom JSON->list->str formatting failed: {0}".format(e))
+                    raise e
+                buffer_formated += str(act_formated) + '\n'
+            fp.write(buffer_formated)
+            fp.close()
+            self.logger.info("saved file %s"%file_name)
+        except Exception, e:
+            self.logger.error("write failed: %s"%e)
+            raise e
+
+# add more custom outputs to this file

--- a/src/CustomOutput.py
+++ b/src/CustomOutput.py
@@ -18,7 +18,7 @@ def make_utc_timestamp(timestamp):
     date_obj = datetime.datetime.strptime(timestamp.split(".")[0], "%Y-%m-%dT%H:%M:%S")
     return str(int((date_obj - datetime.datetime(1970,1,1)).total_seconds()))
 
-class SaveThreadGnacs(SaveThread):
+class SaveCustomLikeCSV(SaveThread):
     def __init__(self, _buffer, _feedname, _savepath, _rootLogger, _startTs, _spanTs, **kwargs):
         SaveThread.__init__(self, _buffer, _feedname, _savepath, _rootLogger, _startTs, _spanTs, **kwargs)
 

--- a/src/CustomOutput.py
+++ b/src/CustomOutput.py
@@ -45,10 +45,10 @@ class SaveCustomLikeCSV(SaveThread):
                     self.logger.error("Custom JSON->list->str formatting failed: {0}".format(e))
                     raise e
                 buffer_formated += str(act_formated) + '\n'
-            fp.write(buffer_formated)
+            fp.write(buffer_formated.encode('utf-8'))
             fp.close()
             self.logger.info("saved file %s"%file_name)
-        except Exception, e:
+        except Exception as e:
             self.logger.error("write failed: %s"%e)
             raise e
 

--- a/src/GnipStreamCollectorMetrics.py
+++ b/src/GnipStreamCollectorMetrics.py
@@ -15,14 +15,6 @@ import sys
 import socket
 import signal
 
-# stream processing strategies
-from SaveThread import SaveThread
-from SaveThreadGnacs import SaveThreadGnacs
-from CountTwitterRules import CountTwitterRules
-from Redis import Redis
-from Latency import Latency
-from Metrics import Metrics
-
 CHUNK_SIZE = 2**17        # decrease for v. low volume streams, > max record size
 GNIP_KEEP_ALIVE = 30      # 30 sec gnip timeout
 MAX_BUF_SIZE = 2**22      # bytes records to hold in memory
@@ -48,8 +40,8 @@ class GnipStreamClient(object):
         self.headers = { 'Accept': 'application/json',
             'Connection': 'Keep-Alive',
             'Accept-Encoding' : 'gzip',
-            'Authorization' : 'Basic %s'%base64.encodestring(
-                '%s:%s'%(_userName, _password))  }
+            'Authorization' : 'Basic %s'%base64.encodestring('%s:%s'%(_userName, _password)).strip()  
+            }
     
     def run(self, **kwargs):
         self.time_roll_start = time.time()
@@ -218,16 +210,23 @@ if __name__ == '__main__':
     proc = []
     for processtype in processtypes:
         if processtype == "latency":
+            from Latency import Latency
             proc.append(Latency)
         elif processtype == "files":
+            from SaveThread import SaveThread
             proc.append(SaveThread)
         elif processtype == "files-gnacs":
+            from SaveThreadGnacs import SaveThreadGnacs
             proc.append(SaveThreadGnacs)
         elif processtype == "rules":
+            from CountTwitterRules import CountTwitterRules
             proc.append(CountTwitterRules)
         elif processtype == "redis":
+            from Redis import Redis
             proc.append(Redis)
         elif processtype == "fileandmetrics":
+            from SaveThread import SaveThread
+            from Metrics import Metrics
             if "sql_db" not in kwargs:
                 logr.error("No database configured.")
                 sys.exit()

--- a/src/GnipStreamCollectorMetrics.py
+++ b/src/GnipStreamCollectorMetrics.py
@@ -232,6 +232,10 @@ if __name__ == '__main__':
                 sys.exit()
             proc.append(SaveThread)
             proc.append(Metrics)
+        else:
+            import CustomOutput
+            if processtype in dir(CustomOutput):
+                proc.append(getattr(CustomOutput, processtype))
     if proc == []: 
         logr.error("No valid processing strategy selected (%s), aborting"%processtype)
         sys.exit(-1)

--- a/src/Metrics.py
+++ b/src/Metrics.py
@@ -38,7 +38,7 @@ class Metrics(SaveThread):
                 continue
             try:
                 activity = json.loads(act)
-            except ValueError, e:
+            except ValueError as e:
                 self.logger.error("Invalid JSON record (%s)"%e)
                 continue
             posted_time = datetime.datetime.utcnow()
@@ -102,7 +102,7 @@ class Metrics(SaveThread):
                            ON DUPLICATE KEY UPDATE count=count + %s;"""
             c.executemany(sql_lang, lang_list)
             db.commit()
-        except Exception, e:
-            print >>sys.stderr,"A MySQL insert error occured (%s)"%str(e)
+        except Exception as e:
+            sys.stderr.write("A MySQL insert error occured (%s)"%str(e))
             db.rollback()
         sys.exit(0)

--- a/src/Redis.py
+++ b/src/Redis.py
@@ -35,9 +35,9 @@ class Redis(SaveThread):
             if "gnip" in actJson:
                 if "matching_rules" in actJson["gnip"]:
                     for mr in actJson["gnip"]["matching_rules"]:
-                        self.logger.debug("inc rule (%s)"%str(mr["value"]))
+                        self.logger.debug("inc rule (%s)"%str(mr["id"]))
                         # Redis store of rule match counts
-                        key = "["+mr["value"]+"]"
+                        key = "["+mr["id"]+"]"
                         rs.incr(key)
                         rs.incr("TotalRuleMatchCount")
                 else:

--- a/src/RedisFreq.py
+++ b/src/RedisFreq.py
@@ -23,7 +23,7 @@ class RedisFreq(object):
                     self.ruleMap[key] = int(rs.get(key))
             except ValueError:
                 sys.stderr.write("valMap or ruleMap Key value error\n") 
-            except redis.exceptions.ResponseError, e:
+            except redis.exceptions.ResponseError as e:
                 sys.stderr.write("Redis response errer (%s)\n"%e)
             except IndexError:
                 sys.stderr.write("List index error (%s)\n"%key)

--- a/src/SaveThread.py
+++ b/src/SaveThread.py
@@ -33,7 +33,7 @@ class SaveThread(threading.Thread):
             try:
                 os.makedirs(file_path)
                 self.logger.info("directory created (%s)"%file_path)
-            except OSError, e:
+            except OSError as e:
                 self.logger.info("directory exists (%s)"%file_path)
             name = self.feedName + "_"
             name += "-".join([
@@ -45,7 +45,7 @@ class SaveThread(threading.Thread):
             file_name = file_path + "/" + name
             with write_lock:
                 self.write(file_name)
-        except Exception, e:
+        except Exception as e:
             self.logger.error("saveAs failed, exiting thread (%s). Exiting."%e)
             raise e
     
@@ -53,10 +53,10 @@ class SaveThread(threading.Thread):
         try:
             # simply write to file
             fp = gzip.open(file_name, "a")
-            fp.write(self.string_buffer)
+            fp.write(self.string_buffer.encode('utf-8'))
             fp.close()
             self.logger.info("saved file %s"%file_name)
-        except Exception, e:
+        except Exception as e:
             self.logger.error("write failed: %s"%e)
             raise e
 

--- a/src/gnip.cfg.example
+++ b/src/gnip.cfg.example
@@ -6,19 +6,21 @@ password=<pwd>
 logfilepath=../log
 
 [stream]
-# Twitter Powertrack stream (Gnip 2.5)
-streamurl=https://stream.gnip.com:443/accounts/shendrickson/publishers/twitter/streams/track/pt1.json
-streamname=Powertrack
-filepath=../data
+# stream
+streamurl=https://gnip-stream.twitter.com/stream/powertrack/accounts/<account name>/publishers/twitter/<stream>.json
+streamname=<name the stream, this shows up in filenames later>
+filepath=../<where your data should go>
 compressed=True
 
 [db]
-sql_instance=<mysqldb host string"
+# note: the SQL interface library being used here does not support Python3, fix outstanding
+sql_instance=<mysqldb host string>
 sql_user_name=<un>
 sql_password=<pwd>
 sql_db=MetricsDB
 
 [gnacs]
+# note: as of right now, GNACS will not be upgraded to support python 3
 options=gulist
 delim=|
 
@@ -28,23 +30,33 @@ rollduration=60
 #
 # NOTE: processtype can be a single value or a comma-separated list of any of the values shown below: 
 # e.g. 
-# processtype=rules,files
+processtype=files,rules
 # processtype=files-gnacs
 
 # sample stream for latency measurements
+# this processtype is python 2&3 compatible
 #processtype=latency
 
 # print out rule production rates
-processtype=rules
+# this processtype is python 2&3 compatible
+#processtype=rules
 
 # store stream contents in files by year, month, day, hour, min
+# this processtype is python 2&3 compatible
 #processtype=files
 
 # as above, but parse output with Gnacs before writing
+# no plans to upgrade GNACS to python 3, this processtype is not python 3 compatible
 #processtype=files-gnacs
 
+# example of a custom processing class
+# this processtype is python 2&3 compatible
+#processtype=SaveCustomLikeCSV
+
 # store stream contents in redis
+# redis not fully tested for python 3
 #processtype=redis
 
 # store stream contents in redis
+# redis is not fully tested for python 3
 #processtype=fileandmetrics


### PR DESCRIPTION
Changes:
- Py3 compatibility for most processtypes
- V2 compatibility for all processtypes
- Changed import locations for processtypes (import as-needed) so that we don't get pointless import errors
- edited some base64 encoding, it was adding a "\n" and crashing the request
- included an example for adding an arbitrary processing module/class for arbitrary output

I still need to add: 
- tests
- a nice way to launch multiple streams at once
+ updated README